### PR TITLE
Add kubescape in vk defination

### DIFF
--- a/vk-definitions.json
+++ b/vk-definitions.json
@@ -272,6 +272,14 @@
                 "GithubOwner": "k14s",
                 "GithubRepo": "ytt",
                 "ReleaseName": "ytt-linux-amd64"
+            },
+            {
+                "Cmd": "kubescape",
+                "VersionArg": "version",
+                "VersionRegexp": "Your current version is: v([0-9]+.[0-9]+.[0-9]+)",
+                "GithubOwner": "armosec",
+                "GithubRepo": "kubescape",
+                "ReleaseName": "kubescape-ubuntu-latest"
             }
         ],
         "untarfile": [


### PR DESCRIPTION
Add kubescape in vk definitions

Debug mode output
```
$ vk debug  --definitions=vk-definitions.json kubescape
Debugging tool kubescape
Struct: &program.GithubDirectDownloadProgram{GithubProgram:program.GithubProgram{Command:program.Command{Path:"/home/sanket/.local/bin", Cmd:"kubescape", VersionArg:"version", VersionRegexp:"Your current version is: v([0-9]+.[0-9]+.[0-9]+)"}, GithubOwner:"armosec", GithubRepo:"kubescape", ReleaseName:"kubescape-ubuntu-latest", DownloadURL:"", PreRelease:false, TagName:""}}
Is installed: false
Latest version: 1.0.130
Download URL: https://github.com/armosec/kubescape/releases/download/v1.0.130/kubescape-ubuntu-latest
```
Install output
```
$ vk install  --definitions=vk-definitions.json kubescape
kubescape version 1.0.130 has been installed.
```
Version output
```
$ kubescape version
Your current version is: v1.0.130
```
After installed, debug mode output
```
$ vk debug  --definitions=vk-definitions.json kubescape
Debugging tool kubescape
Struct: &program.GithubDirectDownloadProgram{GithubProgram:program.GithubProgram{Command:program.Command{Path:"/home/sanket/.local/bin", Cmd:"kubescape", VersionArg:"version", VersionRegexp:"Your current version is: v([0-9]+.[0-9]+.[0-9]+)"}, GithubOwner:"armosec", GithubRepo:"kubescape", ReleaseName:"kubescape-ubuntu-latest", DownloadURL:"", PreRelease:false, TagName:""}}
Is installed: true
Local version: 1.0.130
Latest version: 1.0.130
Download URL: https://github.com/armosec/kubescape/releases/download/v1.0.130/kubescape-ubuntu-latest
```